### PR TITLE
Get rid of Bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem 'rolify'
 gem 'email_validator'
 
 # Styling
-gem 'bootstrap'
 gem 'sassc', '~> 2.4'
 gem 'sassc-rails', '~> 2.1.2'
 gem 'tailwindcss-rails', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,8 +81,6 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    autoprefixer-rails (10.4.19.0)
-      execjs (~> 2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -90,9 +88,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    bootstrap (5.3.3)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.11.8, < 3)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -125,7 +120,6 @@ GEM
     email_validator (2.2.4)
       activemodel
     erubi (1.13.0)
-    execjs (2.10.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.4)
@@ -201,7 +195,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    popper_js (2.11.8)
     psych (5.2.1)
       date
       stringio
@@ -386,7 +379,6 @@ DEPENDENCIES
   actionpack (>= 7.1.5.1)
   actiontext (>= 7.1.4.1)
   bootsnap
-  bootstrap
   capybara
   debug
   devise

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ The most efficient way to set up dev env is to utilize [docker and docker compos
 ### Legacy approach with manual installation
 Also, there is an old less efficient way to set up everything by [manually installing all dependencies](docs/ManualInstallation.md).
 
-### Bootstrap and TailwindCSS
-As we have both Bootstrap and TailwindCSS installed inside the project we need to split them somehow.
-> Thus, to utilize TailwindCSS make sure that you use the classes with the prefix.
-If you want to add a `p-1` class then it should be `tw-p-1` now.
-But it does not apply to the states, for example, if you want to add a `p-2` on hover, then your class should be `hover:tw-p-2`.
-
 ## Useful commands
 - In order to reinit everything run `make reinit`. It will drop all containers and recreate everything from the scratch.
 ### DB management:
@@ -69,7 +63,7 @@ while running `make` command - you [need to install](https://apple.stackexchange
 ### **High Priority**
 
 1. [ ] **Health Data Management**
-   - [ ] User Story 1: Manual input of blood test results.
+   - [x] User Story 1: Manual input of blood test results.
    - [ ] User Story 2: Import health data from PDF files.
    - [x] User Story 4: Display health data with color-coded references.
 2. [ ] **User Interface and Experience**

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,6 @@
  *= require_tree .
  *= require_self
  */
-@import "bootstrap";
 
 .sign-out-button {
   margin-left: 0.5rem;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,47 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.button {
+    @apply inline-block text-center px-4 py-2 rounded;
+}
+
+.primary-button {
+    @apply inline-block text-center px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700;
+}
+
+.secondary-button {
+    @apply inline-block text-center px-4 py-2 rounded bg-gray-600 text-white hover:bg-gray-700;
+}
+
+.outline-secondary-button {
+    @apply inline-block text-center px-4 py-2 rounded border border-gray-600 text-gray-600 hover:bg-gray-100;
+}
+
+.create-button {
+    @apply inline-block text-center px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700;
+}
+
+.outline-create-button {
+    @apply inline-block text-center px-4 py-2 rounded border border-green-600 text-green-600 hover:bg-green-100;
+}
+
+.edit-button {
+    @apply inline-block text-center px-4 py-2 rounded bg-yellow-500 text-white hover:bg-yellow-600;
+}
+
+.delete-button {
+    @apply mt-6 mr-6 mb-6 font-bold py-2 px-4 rounded bg-red-500 text-white hover:bg-red-700;
+}
+
+.outline-primary-button {
+    @apply inline-block text-center px-4 py-2 rounded border border-blue-600 text-blue-600 hover:bg-blue-100;
+}
+
+.large-button {
+    @apply text-lg px-6 py-3;
+}
+
+.small-button {
+    @apply text-sm px-3 py-1;
+}

--- a/app/controllers/lab_tests_controller.rb
+++ b/app/controllers/lab_tests_controller.rb
@@ -4,7 +4,6 @@
 class LabTestsController < ApplicationController
   before_action :set_lab_test, only: %i[show edit update destroy]
   before_action :build_lab_test, only: %i[create]
-  before_action :set_filter_by_user_id, only: %i[index]
   before_action :set_biomarkers, only: %i[index new edit create]
 
   # GET /lab_tests or /lab_tests.json
@@ -30,11 +29,6 @@ class LabTestsController < ApplicationController
     @lab_test = LabTest.new
     authorize @lab_test
     @users = User.all if current_user.full_access_roles_can?
-
-    respond_to do |format|
-      format.html
-      format.turbo_stream { render turbo_stream: turbo_stream.replace('lab_test_form', partial: 'form') }
-    end
   end
 
   # GET /lab_tests/1/edit

--- a/app/controllers/lab_tests_controller.rb
+++ b/app/controllers/lab_tests_controller.rb
@@ -29,7 +29,6 @@ class LabTestsController < ApplicationController
   def new
     @lab_test = LabTest.new
     authorize @lab_test
-    # @biomarkers = Biomarker.all
     @users = User.all if current_user.full_access_roles_can?
 
     respond_to do |format|

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-import "popper"
-import "bootstrap"

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,14 +1,9 @@
 <%= form_with model: @user, url: admin_user_path(@user), method: :patch do |form| %>
   <% if @user.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
-
-      <ul>
-        <% @user.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render "layouts/error_flash",
+               header: "#{pluralize(@user.errors.count, "error")} prohibited this user from being saved:",
+               errors: @user.errors.full_messages
+    %>
   <% end %>
 
   <div>
@@ -27,6 +22,6 @@
   </div>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit class: "my-4 edit-button" %>
   </div>
 <% end %>

--- a/app/views/admin/users/_index_table_body.html.erb
+++ b/app/views/admin/users/_index_table_body.html.erb
@@ -1,23 +1,23 @@
 <tbody>
     <% @users.each do |user| %>
-      <tr id="<%= dom_id user %>" class="tw-bg-white tw-border-b tw-bg-white tw-border-gray-300 tw-hover:bg-gray-700 tw-text-center">
-        <th scope="row" class="tw-px-6 tw-py-4 tw-font-medium tw-text-gray-900 tw-whitespace-nowrap tw-dark:tw-text-white">
+      <tr id="<%= dom_id user %>" class="bg-white border-b bg-white border-gray-300 hover:bg-gray-700 hover:text-white text-center">
+        <th scope="row" class="px-6 py-4 font-medium whitespace-nowrap">
           <%= user.full_name %>
         </th>
-        <td class="tw-px-2 tw-py-2">
+        <td class="px-2 py-2">
           <%= user.email %>
         </td>
-        <td class="tw-px-2 tw-py-2">
+        <td class="px-2 py-2">
           <%= user_roles_list_as_string user %>
         </td>
-        <td class="tw-px-6 tw-py-4">
+        <td class="px-6 py-4">
           <%= format_date_with_time user.created_at %>
         </td>
-        <td class="tw-px-6 tw-py-4">
+        <td class="px-6 py-4">
           <%= format_date_with_time user.updated_at %>
         </td>
-        <td class="tw-px-6 tw-py-4 tw-text-center">
-          <%= link_to "Show details", admin_user_url(user), class: "tw-font-medium tw-text-blue-600 tw-dark:tw-text-blue-500 tw-hover:tw-underline" %>
+        <td class="px-6 py-4 text-center">
+          <%= link_to "Show details", admin_user_url(user), class: "font-medium text-blue-600 dark:text-blue-500 hover:underline" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/users/_index_table_head.html.erb
+++ b/app/views/admin/users/_index_table_head.html.erb
@@ -1,23 +1,23 @@
-<thead class="tw-text-xs tw-text-gray-700 tw-uppercase tw-bg-gray-400 tw-text-center">
+<thead class="text-xs text-gray-700 uppercase bg-gray-400 text-center">
 
 <tr>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     User
   </th>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     Email
   </th>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     Role
   </th>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     Created date
   </th>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     Updated date
   </th>
-  <th scope="col" class="tw-px-6 tw-py-3">
-    <span class="tw-sr-only">Show</span>
+  <th scope="col" class="px-6 py-3">
+    <span class="sr-only">Show</span>
   </th>
 </tr>
 

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,41 +1,41 @@
-<div id="<%= dom_id user %>" class="tw-border-double tw-shadow-lg tw-ring-4 tw-rounded-lg">
-  <div class="tw-m-8 tw-py-4">
+<div id="<%= dom_id user %>" class="border-double shadow-lg ring-4 rounded-lg">
+  <div class="m-8 py-4">
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>User Name:</strong>
       <%= user.full_name %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Email:</strong>
       <%= user.email %>
     </p>
     
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Role:</strong>
       <%= user_roles_list_as_string(user) %>
     </p>
 
     <% if current_user.full_access_roles_can? && assigned?(user) %>
-      <p class="tw-pt-2 tw-pr-6">
+      <p class="pt-2 pr-6">
         <strong>Assigned users:</strong>
         <%= assigned_user_list_as_string user %>
       </p>
     <% end %>
 
     <% if assignees? user %>
-      <p class="tw-pt-2 tw-pr-6">
+      <p class="pt-2 pr-6">
         <strong>Expert you are assigned to:</strong>
         <%= assignees_list_as_string(user) %>
       </p>
     <% end %>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Created at:</strong>
       <%= format_date_with_time user.created_at %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Updated at:</strong>
       <%= format_date_with_time user.updated_at %>
     </p>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,8 +1,16 @@
-<h1>Editing user</h1>
+<h1 class="text-2xl my-3">Editing user</h1>
 
 <%= render "form", user: @user %>
 
 <div>
-  <%= link_to "Show this user", admin_user_url(@user) %> |
-  <%= link_to "Back to users", admin_users_path %>
+  <%= link_to "Show this user",
+              admin_user_url(@user),
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to users",
+              admin_users_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/admin/users/edit_assigned_users.html.erb
+++ b/app/views/admin/users/edit_assigned_users.html.erb
@@ -1,16 +1,11 @@
-<h1>Editing assigned users</h1>
+ <h1 class="text-2xl my-3">Editing assigned users</h1>
 
 <%= form_with model: @user, url: update_assigned_users_admin_user_path(@user), method: :post do |form| %>
   <% if @user.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
-
-      <ul>
-        <% @user.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+     <%= render "layouts/error_flash",
+                header: "#{pluralize(@user.errors.count, "error")} prohibited this user from being saved:",
+                errors: @user.errors.full_messages
+     %>
   <% end %>
 
   <div>
@@ -22,12 +17,20 @@
   </div>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit "Update assignment users", class: "my-4 edit-button" %>
   </div>
 <% end %>
 
 <div>
-  <%= link_to "Show this user", admin_user_url(@user) %> |
-  <%= link_to "Back to users", admin_users_path %>
+  <%= link_to "Show this user",
+              admin_user_url(@user),
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to users",
+              admin_users_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>
 

--- a/app/views/admin/users/edit_roles.html.erb
+++ b/app/views/admin/users/edit_roles.html.erb
@@ -1,16 +1,11 @@
-<h1>Editing user roles</h1>
+ <h1 class="text-2xl my-3">Editing user roles</h1>
 
 <%= form_with model: @user, url: update_roles_admin_user_path(@user), method: :post do |form| %>
   <% if @user.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
-
-      <ul>
-        <% @user.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+     <%= render "layouts/error_flash",
+                header: "#{pluralize(@user.errors.count, "error")} prohibited this user from being saved:",
+                errors: @user.errors.full_messages
+     %>
   <% end %>
 
   <div>
@@ -22,12 +17,20 @@
   </div>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit "Update role", class: "my-4 edit-button" %>
   </div>
 <% end %>
 
 <div>
-  <%= link_to "Show this user", admin_user_url(@user) %> |
-  <%= link_to "Back to users", admin_users_path %>
+  <%= link_to "Show this user",
+              admin_user_url(@user),
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to users",
+              admin_users_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,10 +1,10 @@
 <section>
-  <header class="tw-my-2 tw-flex tw-flex-center tw-justify-between tw-items-center">
-    <h1 class="tw-text-lg">Users</h1>
+  <header class="my-2 flex flex-center justify-between items-center">
+    <h1 class="text-center text-2xl my-3">Users</h1>
   </header>
 
-  <div id="users" class="tw-relative tw-overflow-x-auto tw-shadow-md tw-sm:tw-rounded-lg">
-    <table class="tw-w-full tw-text-sm tw-text-left tw-text-right tw-rounded-md">
+  <div id="users" class="relative overflow-x-auto shadow-md sm:rounded-lg">
+    <table class="w-full text-sm text-left text-right rounded-md">
       <%= render "index_table_head" %>
       <%= render "index_table_body", users: @users %>
     </table>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,18 +1,34 @@
 <%= render "user", user: @user %>
 
 <div>
-  <%= link_to "Edit this user", edit_admin_user_path(@user) %> |
-  <%= link_to "Change this user roles", edit_roles_admin_user_path(@user) %> |
+  <%= link_to "Edit this user",
+              edit_admin_user_path(@user),
+              method: :get,
+              class: "edit-button"
+  %>
+  <%= link_to "Change this user roles",
+              edit_roles_admin_user_path(@user),
+              method: :get,
+              class: "outline-secondary-button"
+  %>
   <% if @user.full_access_roles_can? %>
-    <%= link_to "Update assigned users", edit_assigned_users_admin_user_path(@user) %> |
+    <%= link_to "Update assigned users",
+                edit_assigned_users_admin_user_path(@user),
+                method: :get,
+                class: "outline-secondary-button"
+    %>
   <% end %>
-  <%= link_to "Back to users", admin_users_path %>
+  <%= link_to "Back to users",
+              admin_users_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 
   <%= button_to(
         "Remove this user",
         edit_admin_user_path(@user),
         method: :delete,
         data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-        class: "tw-mt-6 tw-mr-6 tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+        class: "delete-button"
       ) %>
 </div>

--- a/app/views/biomarkers/_biomarker.html.erb
+++ b/app/views/biomarkers/_biomarker.html.erb
@@ -1,14 +1,14 @@
-<tr id="<%= dom_id biomarker %>" class="tw-bg-white tw-border-b tw-bg-white tw-border-gray-300 tw-hover:bg-gray-700 tw-text-center">
-  <th scope="row" class="tw-px-6 tw-py-4 tw-font-medium tw-text-gray-900 tw-whitespace-nowrap tw-dark:tw-text-white">
+<tr id="<%= dom_id biomarker %>" class="bg-white border-b bg-white border-gray-300 hover:bg-gray-700 hover:text-white text-center">
+  <th scope="row" class="px-6 py-4 font-medium whitespace-nowrap">
     <%= biomarker.name %>
   </th>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= format_date_with_time biomarker.created_at %>
   </td>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= format_date_with_time biomarker.updated_at %>
   </td>
-  <td class="tw-px-6 tw-py-4 tw-text-center">
-    <%= link_to "Show details", biomarker, class: "tw-font-medium tw-text-blue-600 tw-dark:tw-text-blue-500 tw-hover:tw-underline" %>
+  <td class="px-6 py-4 text-center">
+    <%= link_to "Show details", biomarker, class: "font-medium text-blue-600 dark:text-blue-500 hover:underline" %>
   </td>
 </tr>

--- a/app/views/biomarkers/_detail_view_biomarker.html.erb
+++ b/app/views/biomarkers/_detail_view_biomarker.html.erb
@@ -1,14 +1,14 @@
-<div id="<%= dom_id biomarker %>" class="tw-border-double tw-shadow-lg tw-ring-4 tw-rounded-lg">
-  <div class="tw-m-8">
+<div id="<%= dom_id biomarker %>" class="border-double shadow-lg ring-4 rounded-lg">
+  <div class="m-8">
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Name:</strong>
       <%= biomarker.name %>
     </p>
 
-    <div class="tw-flex tw-flex-row tw-space-x-4">
+    <div class="flex flex-row space-x-4">
       <% biomarker.reference_ranges.each do |reference_range| %>
-        <div class="tw-basis-1/3 tw-ring-2 tw-rounded-lg tw-p-4 tw-mb-4">
+        <div class="basis-1/3 ring-2 rounded-lg p-4 pb-0 mb-4">
           <p>
             <strong>Min value:</strong>
             <%= format_biomarker_value(reference_range.min_value, reference_range.unit) %>
@@ -40,7 +40,7 @@
                   reference_range,
                   method: :delete,
                   data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-                  class: "tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+                  class: "delete-button font-bold py-2 px-4 rounded"
                 ) %>
           <% end %>
 

--- a/app/views/biomarkers/_form.html.erb
+++ b/app/views/biomarkers/_form.html.erb
@@ -1,14 +1,9 @@
 <%= form_with(model: biomarker) do |form| %>
   <% if biomarker.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(biomarker.errors.count, "error") %> prohibited this biomarker from being saved:</h2>
-
-      <ul>
-        <% biomarker.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render "layouts/error_flash",
+               header: "#{pluralize(biomarker.errors.count, "error")} prohibited this biomarker from being saved:",
+               errors: biomarker.errors.full_messages
+    %>
   <% end %>
 
   <div>
@@ -24,6 +19,6 @@
   <%= render "reference_ranges_form", form: form %>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit class: "my-4 edit-button" %>
   </div>
 <% end %>

--- a/app/views/biomarkers/edit.html.erb
+++ b/app/views/biomarkers/edit.html.erb
@@ -1,12 +1,24 @@
-<h1>Editing biomarker</h1>
+<h1 class="text-2xl my-3">Editing biomarker</h1>
 
 <%= render "form", biomarker: @biomarker %>
 
 <div>
-  <%= link_to "Add Reference Range", new_biomarker_reference_range_path(@biomarker) %>
+  <%= link_to "Add Reference Range",
+              new_biomarker_reference_range_path(@biomarker),
+              method: :get,
+              class: "mb-4 create-button"
+  %>
 </div>
 
 <div>
-  <%= link_to "Show this biomarker", @biomarker %> |
-  <%= link_to "Back to biomarkers", biomarkers_path %>
+  <%= link_to "Show this biomarker",
+              @biomarker,
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to biomarkers",
+              biomarkers_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/biomarkers/index.html.erb
+++ b/app/views/biomarkers/index.html.erb
@@ -1,28 +1,28 @@
 <section>
 
-  <header class="tw-my-2 tw-flex tw-flex-center tw-justify-between tw-items-center">
-    <h1 class="tw-text-lg">Biomarkers</h1>
-    <%= link_to "New biomarker", new_biomarker_path, class: "btn btn-primary" %>
+  <header class="my-2 flex flex-center justify-between items-center">
+    <h1 class="text-center text-2xl my-3">Biomarkers</h1>
+    <%= link_to "New biomarker", new_biomarker_path, class: "create-button" %>
   </header>
 
-  <div id="new_biomarkers" class="tw-relative tw-overflow-x-auto tw-shadow-md tw-sm:tw-rounded-lg">
+  <div id="new_biomarkers" class="relative overflow-x-auto shadow-md sm:rounded-lg">
 
-    <table class="tw-w-full tw-text-sm tw-text-left tw-text-right tw-rounded-md">
+    <table class="w-full text-sm text-left text-right rounded-md">
 
-      <thead class="tw-text-xs tw-text-gray-700 tw-uppercase tw-bg-gray-400 tw-text-center">
+      <thead class="text-xs text-gray-700 uppercase bg-gray-400 text-center">
 
       <tr>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Name
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Created date
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Updated date
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
-          <span class="tw-sr-only">Show</span>
+        <th scope="col" class="px-6 py-3">
+          <span class="sr-only">Show</span>
         </th>
       </tr>
 

--- a/app/views/biomarkers/new.html.erb
+++ b/app/views/biomarkers/new.html.erb
@@ -1,7 +1,11 @@
-<h1>New biomarker</h1>
+<h1 class="text-2xl my-3">New biomarker</h1>
 
 <%= render "form", biomarker: @biomarker %>
 
 <div>
-  <%= link_to "Back to biomarkers", biomarkers_path %>
+  <%= link_to "Back to biomarkers",
+              biomarkers_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/biomarkers/show.html.erb
+++ b/app/views/biomarkers/show.html.erb
@@ -2,9 +2,17 @@
 
 <div>
   <% if policy(@biomarker).edit? %>
-    <%= link_to "Edit this biomarker", edit_biomarker_path(@biomarker) %> |
+    <%= link_to "Edit this biomarker",
+                edit_biomarker_path(@biomarker),
+                method: :get,
+                class: "edit-button"
+    %>
   <% end %>
-  <%= link_to "Back to biomarkers", biomarkers_path %>
+  <%= link_to "Back to biomarkers",
+              biomarkers_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 
   <% if policy(@biomarker).destroy? %>
     <%= button_to(
@@ -12,7 +20,7 @@
           @biomarker,
           method: :delete,
           data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-          class: "tw-mt-6 tw-mr-6 tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+          class: "delete-button"
         ) %>
   <% end %>
 </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,17 +1,17 @@
-<h2 class="page-title">Resend confirmation instructions</h2>
+<h2 class="text-center text-2xl my-3">Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :email, class:"form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Resend confirmation instructions", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Resend confirmation instructions", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
 
     <%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,26 +1,26 @@
-<h2 class="page-title">Change your password</h2>
+<h2 class="text-center text-2xl my-3">Change your password</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :password, "New password", class:"form-label" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :password, "New password", class: "block text-sm font-medium text-gray-700" %>
       <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <em class="text-sm text-gray-500">(<%= @minimum_password_length %> characters minimum)</em>
       <% end %>
-      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class:"form-control"  %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :password_confirmation, "Confirm new password", class:"form-label" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control"  %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :password_confirmation, "Confirm new password", class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Change my password", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Change my password", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
 
     <%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,17 +1,17 @@
-<h2 class="page-title">Forgot your password?</h2>
+<h2 class="text-center text-2xl my-3">Forgot your password?</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Send me reset password instructions", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Send me reset password instructions", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
 
     <%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,58 +1,59 @@
-<h2 class="page-title">Edit <%= resource_name.to_s.humanize %></h2>
+<h2 class="text-center text-2xl my-3">Edit <%= resource_name.to_s.humanize %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :email, class:"form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div>
-      <%= f.label :first_name, class:"form-label" %><br />
-      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", class:"form-control"  %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :first_name, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div>
-      <%= f.label :last_name, class:"form-label" %><br />
-      <%= f.text_field :last_name, autofocus: true, autocomplete: "last_name", class:"form-control"  %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :last_name, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :last_name, autofocus: true, autocomplete: "last_name", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
 
-    <div class="form-group mb-3  w-50">
-      <%= f.label :password, class:"form-label" %> <i>(leave blank if you don't want to change it)</i>
-      <%= f.password_field :password, autocomplete: "new-password", class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+      <i>(leave blank if you don't want to change it)</i>
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
       <% if @minimum_password_length %>
-        <em><%= @minimum_password_length %> characters minimum</em>
+        <em class="text-sm text-gray-500"><%= @minimum_password_length %> characters minimum</em>
       <% end %>
     </div>
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :password_confirmation, class:"form-label" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :current_password, class:"form-label" %> <i>(we need your current password to confirm your changes)</i>
-      <%= f.password_field :current_password, autocomplete: "current-password", class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :current_password, class: "block text-sm font-medium text-gray-700" %>
+      <i>(we need your current password to confirm your changes)</i>
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Update", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Update", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
-
   </div>
 <% end %>
 
-<div class="d-flex flex-column justify-content-center align-items-center">
-  <h3>Cancel my account</h3>
+<div class="flex flex-col justify-center items-center">
+  <h3 class="text-lg font-semibold mb-2">Cancel my account</h3>
 
-  <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class:"btn btn-lg btn-danger" %>
+  <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "inline-block text-center px-6 py-3 rounded text-lg bg-red-600 text-white hover:bg-red-700" %>
 
-  <%= link_to "Back", :back %>
+  <%= link_to "Back", :back, class: "mt-3 text-blue-600 hover:underline" %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,40 +1,40 @@
-<h2 class="page-title">Sign up</h2>
+<h2 class="text-center text-2xl my-3">Sign up</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :email, class: "form-label"%>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div>
-      <%= f.label :first_name, class:"form-label" %><br />
-      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", class:"form-control"  %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :first_name, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div>
-      <%= f.label :last_name, class:"form-label" %><br />
-      <%= f.text_field :last_name, autofocus: true, autocomplete: "last_name", class:"form-control"  %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :last_name, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.text_field :last_name, autofocus: true, autocomplete: "last_name", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :password, class:"form-label" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
       <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <em class="text-sm text-gray-500">(<%= @minimum_password_length %> characters minimum)</em>
       <% end %>
-      <%= f.password_field :password, autocomplete: "new-password", class:"form-control" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :password_confirmation, class:"form-label" %>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Sign up", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Sign up", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
 
     <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,28 +1,28 @@
-<h2 class="page-title">Log in</h2>
+<h2 class="text-center text-2xl my-3">Log in</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center w-1/3 mx-auto">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :email, class: "form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control"  %>
+    <div class="mb-3 w-full">
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :password, class: "form-label" %>
-      <%= f.password_field :password, autocomplete: "current-password", class:"form-control" %>
+    <div class="mb-3  w-full">
+      <%= f.label :password, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
     <% if devise_mapping.rememberable? %>
-      <div class="form-check mb-3 w-50">
-        <%= f.check_box :remember_me, class:"form-check-input" %>
-        <%= f.label :remember_me, class:"form-check-label" %>
+      <div class="mb-3 w-full flex items-center">
+        <%= f.check_box :remember_me, class: "h-4 w-4 text-blue-600 focus:ring focus:ring-blue-500 focus:ring-opacity-50 border-gray-300 rounded" %>
+        <%= f.label :remember_me, class: "ml-2 block text-sm text-gray-700" %>
       </div>
     <% end %>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Log in", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Log in", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
 
     <%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,20 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="p-4 rounded border bg-red-100 border-red-400 text-red-800 mt-4 fixed right-2 top-12" data-turbo-cache="false">
+    <h2 class="font-bold text-center text-2xl my-3">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="list-disc list-inside">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>
+    <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Close" onclick="this.parentElement.remove()">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
   </div>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,19 +1,19 @@
-<h2 class="page-title">Resend unlock instructions</h2>
+<h2 class="text-center text-2xl my-3">Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="d-flex flex-column justify-content-center align-items-center">
+  <div class="flex flex-col justify-center items-center">
 
-    <div class="form-group mb-3 w-50">
-      <%= f.label :email, class:"form-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"form-control" %>
+    <div class="mb-3 w-1/2">
+      <%= f.label :email, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50" %>
     </div>
 
-    <div class="mb-3 d-flex align-items-center justify-content-center">
-      <%= f.submit "Resend unlock instructions", class:"btn btn-lg btn-primary" %>
+    <div class="mb-3 flex items-center justify-center">
+      <%= f.submit "Resend unlock instructions", class: "inline-block text-center px-6 py-3 rounded text-lg bg-blue-600 text-white hover:bg-blue-700" %>
     </div>
 
-    <%= render "devise/shared/links" %>`
+    <%= render "devise/shared/links" %>
   </div>
 <% end %>

--- a/app/views/health_records/_detail_view_lab_tests.html.erb
+++ b/app/views/health_records/_detail_view_lab_tests.html.erb
@@ -1,6 +1,6 @@
-<div class="tw-grid tw-grid-cols-3 tw-gap-4">
+<div class="grid grid-cols-3 gap-4">
   <% health_record.lab_tests.each do |lab_test| %>
-    <div class="tw-ring-2 tw-rounded-lg tw-p-4 tw-bg-teal-500">
+    <div class="ring-2 rounded-lg p-4 pb-0 bg-teal-500">
 
       <p>
         <strong>Biomarker Name:</strong>
@@ -38,7 +38,7 @@
               lab_test,
               method: :delete,
               data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-              class: "tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+              class: "delete-button font-bold py-2 px-4 rounded"
             ) %>
       <% end %>
 

--- a/app/views/health_records/_detail_view_measurements.html.erb
+++ b/app/views/health_records/_detail_view_measurements.html.erb
@@ -1,6 +1,6 @@
-<div class="tw-grid tw-grid-cols-3 tw-gap-4">
+<div class="grid grid-cols-3 gap-4">
   <% health_record.measurements.each do |measurement| %>
-    <div class="tw-ring-2 tw-rounded-lg tw-p-4 tw-mb-4 tw-bg-yellow-200">
+    <div class="ring-2 rounded-lg p-4 mb-4 bg-yellow-200 pb-0">
 
       <p>
         <strong>Measurement Type:</strong>
@@ -38,7 +38,7 @@
               measurement,
               method: :delete,
               data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-              class: "tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+              class: "delete-button font-bold py-2 px-4 rounded"
             ) %>
       <% end %>
 

--- a/app/views/health_records/_form.html.erb
+++ b/app/views/health_records/_form.html.erb
@@ -1,14 +1,9 @@
 <%= form_with(model: health_record) do |form| %>
   <% if health_record.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(health_record.errors.count, "error") %> prohibited this health_record from being saved:</h2>
-
-      <ul>
-        <% health_record.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render "layouts/error_flash",
+               header: "#{pluralize(health_record.errors.count, "error")} prohibited this health record from being saved:",
+               errors: health_record.errors.full_messages
+    %>
   <% end %>
 
   <div>
@@ -17,6 +12,6 @@
   </div>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit class: "my-4 edit-button" %>
   </div>
 <% end %>

--- a/app/views/health_records/_health_record.html.erb
+++ b/app/views/health_records/_health_record.html.erb
@@ -1,17 +1,17 @@
-<tr id="<%= dom_id health_record %>" class="tw-bg-white tw-border-b tw-bg-white tw-border-gray-300 tw-hover:bg-gray-700 tw-text-center">
-  <th scope="row" class="tw-px-6 tw-py-4 tw-font-medium tw-text-gray-900 tw-whitespace-nowrap tw-dark:tw-text-white">
+<tr id="<%= dom_id health_record %>" class="bg-white border-b bg-white border-gray-300 hover:bg-gray-700 hover:text-white text-center">
+  <th scope="row" class="px-6 py-4 font-medium whitespace-nowrap">
     <%= health_record.user.full_name %>
   </th>
-  <td class="tw-px-2 tw-py-2 tw-text-ellipsis tw-overflow-hidden tw-max-w-20 tw-whitespace-nowrap">
+  <td class="px-2 py-2 text-ellipsis overflow-hidden max-w-20 whitespace-nowrap">
     <%= health_record.notes %>
   </td>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= format_date_with_time health_record.created_at %>
   </td>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= format_date_with_time health_record.updated_at %>
   </td>
-  <td class="tw-px-6 tw-py-4 tw-text-center">
-    <%= link_to "Show details", health_record, class: "tw-font-medium tw-text-blue-600 tw-dark:tw-text-blue-500 tw-hover:tw-underline" %>
+  <td class="px-6 py-4 text-center">
+    <%= link_to "Show details", health_record, class: "font-medium text-blue-600 dark:text-blue-500 hover:underline" %>
   </td>
 </tr>

--- a/app/views/health_records/edit.html.erb
+++ b/app/views/health_records/edit.html.erb
@@ -1,8 +1,16 @@
-<h1>Editing health record</h1>
+<h1 class="text-2xl my-3">Editing health record</h1>
 
 <%= render "form", health_record: @health_record %>
 
 <div>
-  <%= link_to "Show this health record", @health_record %> |
-  <%= link_to "Back to health records", health_records_path %>
+  <%= link_to "Show this health record",
+              @health_record,
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to health records",
+              health_records_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/health_records/index.html.erb
+++ b/app/views/health_records/index.html.erb
@@ -1,31 +1,31 @@
 <section>
 
-  <header class="tw-my-2 tw-flex tw-flex-center tw-justify-between tw-items-center">
-    <h1 class="tw-text-lg">Health records</h1>
-    <%= link_to "New health record", new_health_record_path, class: "btn btn-primary" %>
+  <header class="my-2 flex flex-center justify-between items-center">
+    <h1 class="text-center text-2xl my-3">Health records</h1>
+    <%= link_to "New health record", new_health_record_path, class: "create-button" %>
   </header>
 
-  <div id="health_records" class="tw-relative tw-overflow-x-auto tw-shadow-md tw-sm:tw-rounded-lg">
+  <div id="health_records" class="relative overflow-x-auto shadow-md sm:rounded-lg">
 
-    <table class="tw-w-full tw-text-sm tw-text-left tw-text-right tw-rounded-md">
+    <table class="w-full text-sm text-left text-right rounded-md">
 
-      <thead class="tw-text-xs tw-text-gray-700 tw-uppercase tw-bg-gray-400 tw-text-center">
+      <thead class="text-xs text-gray-700 uppercase bg-gray-400 text-center">
 
       <tr>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           User
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Notes
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Created date
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Updated date
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
-          <span class="tw-sr-only">Show</span>
+        <th scope="col" class="px-6 py-3">
+          <span class="sr-only">Show</span>
         </th>
       </tr>
 

--- a/app/views/health_records/new.html.erb
+++ b/app/views/health_records/new.html.erb
@@ -1,7 +1,11 @@
-<h1>New health record</h1>
+<h1 class="text-2xl my-3">New health record</h1>
 
 <%= render "form", health_record: @health_record %>
 
 <div>
-  <%= link_to "Back to health records", health_records_path %>
+  <%= link_to "Back to health records",
+              health_records_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/health_records/show.html.erb
+++ b/app/views/health_records/show.html.erb
@@ -1,36 +1,44 @@
-<div id="<%= dom_id @health_record %>" class="tw-border-double tw-shadow-lg tw-ring-4 tw-pb-0.5 tw-mb-2 tw-rounded-lg">
-  <div class="tw-m-8">
+<div id="<%= dom_id @health_record %>" class="border-double shadow-lg ring-4 pb-0.5 mb-2 rounded-lg">
+  <div class="m-8">
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Full Name:</strong>
       <%= @health_record.user.full_name %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Notes:</strong>
       <%= @health_record.notes %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Created at:</strong>
       <%= format_date_with_time @health_record.created_at %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Updated at:</strong>
       <%= format_date_with_time @health_record.updated_at %>
     </p>
 
-    <div>
-      <%= link_to "Edit this health record", edit_health_record_path(@health_record) %> |
-      <%= link_to "Back to health records", health_records_path %>
+    <div class="mt-9">
+      <%= link_to "Edit this health record",
+                  edit_health_record_path(@health_record),
+                  method: :get,
+                  class: "edit-button"
+      %>
+      <%= link_to "Back to health records",
+                  health_records_path,
+                  method: :get,
+                  class: "secondary-button"
+      %>
 
       <%= button_to(
             "Remove this Health Record",
             @health_record,
             method: :delete,
             data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-            class: "tw-mt-6 tw-mr-6 tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+            class: "delete-button"
           ) %>
     </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,37 @@
-<h1 class="tw-text-3xl tw-font-bold">
+<h1 class="text-3xl font-bold text-center my-5">
   Welcome to Health Keeper
 </h1>
+<ul class="flex gap-4">
+  <li class="border p-8 rounded-xl w-64 h-64">
+  <%= link_to "My health records",
+              health_records_path,
+              method: :get,
+      class: "text-bold underline"
+  %>
+  <p class="mt-4">Look at all records about your health</p>
+</li>
+  <li class="border p-8 rounded-xl  w-64 h-64">
+    <%= link_to "My Lab tests",
+                lab_tests_path,
+                method: :get,
+        class: "text-bold underline"
+    %>
+    <p class="mt-4">Look at results of your lab tests</p>
+  </li>
+  <li class="border p-8 rounded-xl  w-64 h-64">
+    <%= link_to "My Measurements",
+                measurements_path,
+                method: :get,
+                class: "text-bold underline"
+    %>
+    <p class="mt-4">Store all data about your body measurements</p>
+  </li>
+  <li class="border p-8 rounded-xl  w-64 h-64">
+    <%= link_to "My biomarkers",
+                biomarkers_path,
+                method: :get,
+                class: "text-bold underline"
+    %>
+    <p class="mt-4">All available biomarkers data</p>
+  </li>
+</ul>

--- a/app/views/lab_tests/_form.html.erb
+++ b/app/views/lab_tests/_form.html.erb
@@ -1,10 +1,10 @@
-<%= form_with(model: lab_test) do |form| %>
-<% if lab_test.errors.any? %>
+<%= form_with(model: @lab_test) do |form| %>
+<% if @lab_test.errors.any? %>
 <div style="color: red">
-    <h2><%= pluralize(lab_test.errors.count, "error") %> prohibited this lab_test from being saved:</h2>
+    <h2><%= pluralize(@lab_test.errors.count, "error") %> prohibited this @lab_test from being saved:</h2>
 
     <ul>
-        <% lab_test.errors.each do |error| %>
+        <% @lab_test.errors.each do |error| %>
         <li><%= error.full_message %></li>
         <% end %>
     </ul>
@@ -37,6 +37,6 @@
 </div>
 
 <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit class: "my-4 edit-button" %>
 </div>
 <% end %>

--- a/app/views/lab_tests/_index_table.html.erb
+++ b/app/views/lab_tests/_index_table.html.erb
@@ -1,5 +1,5 @@
-<div id="lab_tests" class="tw-relative tw-overflow-x-auto tw-shadow-md tw-sm:tw-rounded-lg">
-  <table class="tw-w-full tw-text-sm tw-text-left tw-text-right tw-rounded-md">
+<div id="lab_tests" class="relative overflow-x-auto shadow-md sm:rounded-lg">
+  <table class="w-full text-sm text-left text-right rounded-md">
     <%= render "index_table_head", recordables: @recordables %>
     <%= render "index_table_body", recordables: @recordables, biomarkers: @biomarkers %>
   </table>

--- a/app/views/lab_tests/_index_table_body.html.erb
+++ b/app/views/lab_tests/_index_table_body.html.erb
@@ -1,27 +1,27 @@
 <tbody>
 <% biomarkers.each do |biomarker| %>
-  <tr id="<%= dom_id biomarker %>" class="tw-bg-white tw-border-b tw-bg-white tw-border-gray-300 tw-hover:bg-gray-700 tw-text-left">
-    <td class="tw-px-6 tw-py-4">
+  <tr id="<%= dom_id biomarker %>" class="bg-white border-b bg-white border-gray-300 hover:bg-gray-700 hover:text-white text-left">
+    <td class="px-6 py-4">
       <%= biomarker.name %>
     </td>
-    <td class="tw-px-6 tw-py-4">
+    <td class="px-6 py-4">
       <%= format_reference_range(biomarker.reference_ranges.first.min_value, biomarker.reference_ranges.first.max_value, biomarker.reference_ranges.first.unit) %>
     </td>
     <% recordables.each do |recordable| %>
       <% lab_test = biomarker.lab_tests.find { |lt| lt.recordable_id == recordable.recordable_id } %>
       <% if lab_test %>
-        <td class="tw-px-6 tw-py-4<%= " tw-bg-red-500" unless lab_test.value.between?(biomarker.reference_ranges.first.min_value, biomarker.reference_ranges.first.max_value) %>">
-          <div class="tw-flex">
+        <td class="px-6 py-4<%= " bg-red-500" unless lab_test.value.between?(biomarker.reference_ranges.first.min_value, biomarker.reference_ranges.first.max_value) %>">
+          <div class="flex">
             <%= format_biomarker_value lab_test.value, lab_test.unit %>
             <%= link_to lab_test, data: { turbo: "false" } do %>
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="tw-size-6">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 8.25 21 12m0 0-3.75 3.75M21 12H3"/>
               </svg>
             <% end %>
           </div>
         </td>
       <% else %>
-        <td class="tw-px-6 tw-py-4"></td>
+        <td class="px-6 py-4"></td>
       <% end %>
     <% end %>
   </tr>

--- a/app/views/lab_tests/_index_table_head.html.erb
+++ b/app/views/lab_tests/_index_table_head.html.erb
@@ -1,14 +1,14 @@
-<thead class="tw-text-xs tw-text-gray-700 tw-uppercase tw-bg-gray-400 tw-text-left">
+<thead class="text-xs text-gray-700 uppercase bg-gray-400 text-left">
 
 <tr>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     Biomarker
   </th>
-  <th scope="col" class="tw-px-6 tw-py-3">
+  <th scope="col" class="px-6 py-3">
     Reference range
   </th>
   <% recordables.each do |recordable| %>
-    <th scope="col" class="tw-px-6 tw-py-3">
+    <th scope="col" class="px-6 py-3">
       <%= format_date recordable.created_at %>
     </th>
   <% end %>

--- a/app/views/lab_tests/_lab_test.html.erb
+++ b/app/views/lab_tests/_lab_test.html.erb
@@ -1,32 +1,32 @@
-<div id="<%= dom_id lab_test %>" class="tw-border-double tw-shadow-lg tw-ring-4 tw-rounded-lg">
-  <div class="tw-m-8 tw-py-4">
+<div id="<%= dom_id lab_test %>" class="border-double shadow-lg ring-4 rounded-lg">
+  <div class="m-8 py-4">
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Biomarker Name:</strong>
       <%= lab_test.biomarker.name %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Value:</strong>
       <%= format_biomarker_value(lab_test.value, lab_test.unit) %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Reference range:</strong>
       <%= format_reference_range(lab_test.reference_range.min_value, lab_test.reference_range.max_value, lab_test.reference_range.unit) %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Notes:</strong>
       <%= lab_test.notes %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Created at:</strong>
       <%= format_date_with_time lab_test.created_at %>
     </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
       <strong>Updated at:</strong>
       <%= format_date_with_time lab_test.updated_at %>
     </p>

--- a/app/views/lab_tests/edit.html.erb
+++ b/app/views/lab_tests/edit.html.erb
@@ -1,8 +1,16 @@
-<h1>Editing lab test</h1>
+<h1 class="text-2xl my-3">Editing lab test</h1>
 
 <%= render "form", lab_test: @lab_test %>
 
 <div>
-  <%= link_to "Show this lab test", @lab_test %> |
-  <%= link_to "Back to lab tests", lab_tests_path %>
+  <%= link_to "Show this lab test",
+              @lab_test,
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to lab tests",
+              lab_tests_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/lab_tests/index.html.erb
+++ b/app/views/lab_tests/index.html.erb
@@ -1,10 +1,10 @@
 <section>
-  <header class="tw-my-2 tw-flex tw-flex-center tw-justify-between tw-items-center">
-    <h1 class="tw-text-lg">Lab Tests</h1>
+  <header class="my-2 flex flex-center justify-between items-center">
+    <h1 class="text-center text-2xl my-3">Lab Tests</h1>
     <%= link_to "New Lab Test",
                 new_lab_test_path,
                 method: :get,
-                class: "btn btn-primary",
+                class: "create-button",
                 data: { turbo_frame: "_top" }
     %>
   </header>

--- a/app/views/lab_tests/new.html.erb
+++ b/app/views/lab_tests/new.html.erb
@@ -15,7 +15,8 @@
         <%= label_tag :user_id, "Select Patient", class: "block text-sm font-medium text-gray-700" %>
         <%= form.select :user_id,
             options_for_select(
-              assigned_users_list_for_select(current_user, current_user)
+              assigned_users_list_for_select(current_user, current_user),
+              @chosen_user_id
             ),
             { include_blank: false },
             class: "border-blue-500 rounded"

--- a/app/views/lab_tests/new.html.erb
+++ b/app/views/lab_tests/new.html.erb
@@ -1,30 +1,18 @@
-<div class="tw-container tw-mx-auto tw-p-4">
-    <h1 class="tw-text-2xl tw-font-bold tw-mb-4">New <%= params[:test_type]&.titleize || 'Lab' %> Test</h1>
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl my-3">New <%= params[:test_type]&.titleize || 'Lab' %> Test</h1>
+
+    <%= form_with(model: @lab_test, local: true, class: "space-y-4") do |form| %>
 
     <% if @lab_test.errors.any? %>
-    <div class="alert alert-danger alert-dismissible fade show tw-mt-4" role="alert">
-        <h2 class="tw-font-bold tw-text-lg">
-            <%= pluralize(@lab_test.errors.count, "error") %> prohibited this test from being saved:
-        </h2>
-        <ul class="tw-list-disc tw-list-inside">
-            <% @lab_test.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-            <% end %>
-        </ul>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
-    <% elsif flash.present? %>
-    <div class="alert alert-<%= flash.notice.present? ? 'success': 'danger' %> alert-dismissible fade show tw-mt-4" role="alert">
-        <%= flash.notice.present? ? flash.notice : flash.alert %>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
+      <%= render "layouts/error_flash",
+                 header: "#{pluralize(@lab_test.errors.count, "error")} prohibited this lab test from being saved:",
+                 errors: @lab_test.errors.full_messages
+      %>
     <% end %>
 
-    <%= form_with(model: @lab_test, local: true, class: "tw-space-y-4") do |form| %>
-
     <% if assigned_users? %>
-    <div class="tw-mb-4">
-        <%= label_tag :user_id, "Select Patient", class: "tw-block tw-text-sm tw-font-medium tw-text-gray-700" %>
+    <div class="mb-4">
+        <%= label_tag :user_id, "Select Patient", class: "block text-sm font-medium text-gray-700" %>
         <%= form.select :user_id,
             options_for_select(
               assigned_users_list_for_select(current_user, current_user)
@@ -37,14 +25,14 @@
     <%= form.hidden_field :user_id, value: current_user.id %>
     <% end %>
 
-    <div class="tw-mb-4" data-controller="biomarker-select">
-        <%= form.label :biomarker_id, class: "tw-block tw-text-sm tw-font-medium tw-text-gray-700" %>
+    <div class="mb-4" data-controller="biomarker-select">
+        <%= form.label :biomarker_id, class: "block text-sm font-medium text-gray-700" %>
         <%= form.collection_select :biomarker_id,
                 @biomarkers,
                 :id,
                 :name,
                 { prompt: "Select biomarker", required: true },
-                { class: "tw-mt-1 tw-block tw-w-full tw-rounded-md #{@lab_test.errors[:biomarker_id].present? ? 'tw-border-red-500' : 'tw-border-gray-300'}",
+                { class: "mt-1 block w-full rounded-md #{@lab_test.errors[:biomarker_id].present? ? 'border-red-500' : 'border-gray-300'}",
                   data: {
                     biomarker_select_target: "select",
                     action: "change->biomarker-select#updateReferenceRange"
@@ -52,11 +40,11 @@
                 }
               %>
         <% if @lab_test.errors[:biomarker_id].any? %>
-        <p class="tw-text-red-500 tw-text-sm tw-mt-1"><%= @lab_test.errors[:biomarker_id].join(', ') %></p>
+        <p class="text-red-500 text-sm mt-1"><%= @lab_test.errors[:biomarker_id].join(', ') %></p>
         <% end %>
 
-        <div id="reference_range_info" class="tw-mt-2 tw-p-4 tw-bg-gray-50 tw-rounded-md">
-            <p class="tw-text-sm tw-text-gray-600">
+        <div id="reference_range_info" class="mt-2 p-4 bg-gray-50 rounded-md">
+            <p class="text-sm text-gray-600">
                 <strong>Reference Range:</strong>
                 <span data-biomarker-select-target="referenceRange">
                     <%= @selected_biomarker&.reference_ranges&.first ?
@@ -64,7 +52,7 @@
                         "Select biomarker first" %>
                 </span>
             </p>
-            <p class="tw-text-sm tw-text-gray-600">
+            <p class="text-sm text-gray-600">
                 <strong>Unit:</strong>
                 <span data-biomarker-select-target="unit">
                     <%= @selected_biomarker&.reference_ranges&.first&.unit || '-' %>
@@ -80,28 +68,32 @@
             data: { biomarker_select_target: "unitField" } %>
     </div>
 
-    <div class="tw-mb-4">
-        <%= form.label :value, class: "tw-block tw-text-sm tw-font-medium tw-text-gray-700" %>
-        <div class="tw-flex tw-items-center">
+    <div class="mb-4">
+        <%= form.label :value, class: "block text-sm font-medium text-gray-700" %>
+        <div class="flex items-center">
             <%= form.number_field :value,
                     step: :any,
                     required: true,
-                    class: "tw-mt-1 tw-block tw-w-full tw-rounded-md #{@lab_test.errors[:value].present? ? 'tw-border-red-500' : 'tw-border-gray-300'}"
+                    class: "mt-1 block w-full rounded-md #{@lab_test.errors[:value].present? ? 'border-red-500' : 'border-gray-300'}"
                 %>
         </div>
 
     </div>
 
-    <div class="tw-mb-4">
-        <%= form.label :notes, class: "tw-block tw-text-sm tw-font-medium tw-text-gray-700" %>
-        <%= form.text_area :notes, class: "tw-mt-1 tw-block tw-w-full tw-rounded-md tw-border-gray-300" %>
+    <div class="mb-4">
+        <%= form.label :notes, class: "block text-sm font-medium text-gray-700" %>
+        <%= form.text_area :notes, class: "mt-1 block w-full rounded-md border-gray-300" %>
     </div>
 
     <%= form.submit "Create #{params[:test_type]&.titleize || 'Lab'} Test",
-                   class: "tw-bg-blue-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+                   class: "edit-button" %>
     <% end %>
 
-    <div class="tw-mt-4">
-        <%= link_to "Back to lab tests", lab_tests_path, class: "tw-text-blue-500 hover:tw-text-blue-700" %>
+    <div class="mt-4">
+        <%= link_to "Back to lab tests",
+                    lab_tests_path,
+                    method: :get,
+                    class: "secondary-button"
+        %>
     </div>
 </div>

--- a/app/views/lab_tests/show.html.erb
+++ b/app/views/lab_tests/show.html.erb
@@ -1,14 +1,22 @@
 <%= render "lab_test", lab_test: @lab_test %>
 
 <div>
-  <%= link_to "Edit this lab test", edit_lab_test_path(@lab_test) %> |
-  <%= link_to "Back to lab tests", lab_tests_path %>
+  <%= link_to "Edit this lab test",
+              edit_lab_test_path(@lab_test),
+              method: :get,
+              class: "edit-button"
+  %>
+  <%= link_to "Back to lab tests",
+              lab_tests_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 
   <%= button_to(
         "Remove this lab test",
         @lab_test,
         method: :delete,
         data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-        class: "tw-mt-6 tw-mr-6 tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+        class: "delete-button"
       ) %>
 </div>

--- a/app/views/layouts/_error_flash.html.erb
+++ b/app/views/layouts/_error_flash.html.erb
@@ -1,0 +1,17 @@
+<div class="p-4 rounded border bg-red-100 border-red-400 text-red-800 mt-4 fixed right-2 top-12" role="alert">
+  <h2 class="font-bold text-center text-2xl my-3">
+    <%= header %>
+  </h2>
+  <% unless errors.empty? %>
+    <ul class="list-disc list-inside">
+      <% errors.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Close" onclick="this.parentElement.remove()">
+    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  </button>
+</div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,6 +1,10 @@
 <% if flash.present? %>
-  <div class="alert alert-<%= flash.notice.present? ? 'success': 'danger' %> alert-dismissible fade show tw-mt-4" role="alert">
+  <div class="p-4 rounded border <%= flash.notice.present? ? 'bg-green-100 border-green-400 text-green-800' : 'bg-red-100 border-red-400 text-red-800' %> mt-4 fixed top-12 right-2 pr-9" role="alert">
     <%= flash.notice.present? ? flash.notice : flash.alert %>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    <button type="button" class="absolute top-1 right-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Close" onclick="this.parentElement.remove()">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
   </div>
 <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,55 +1,43 @@
-<nav class="navbar navbar-expand-lg bg-light">
-  <div class="container">
-    <a class="navbar-brand tw-w-10 tw-h-10" href="/">
-      <%= image_tag("logo.png", alt: "Logo") %>
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarTogglerDemo02" aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item">
-          <% %>
-          <%= link_to "Health records", health_records_path, class: "nav-link #{current_page?(health_records_path) ? 'active' : ''}" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Lab tests", lab_tests_path, class: "nav-link #{current_page?(lab_tests_path) ? 'active' : ''}" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Measurements", measurements_path, class: "nav-link #{current_page?(measurements_path) ? 'active' : ''}" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Biomarkers", biomarkers_path, class: "nav-link #{current_page?(biomarkers_path) ? 'active' : ''}" %>
-        </li>
-        <li class="nav-item">
-          <% if current_user&.admin? %>
-            <%= link_to "Users", admin_users_path, class: "nav-link #{current_page?(admin_users_path) ? 'active' : ''}" %>
-          <% end %>
-        </li>
-        <li class="nav-item">
-          <% if assigned_users? %>
-            <div class="flex justify-end mb-1">
-              <%= form_with url: switch_user_admin_user_path(current_user), method: :post do |form| %>
-                <%= form.select :user_id,
-                                options_for_select(
-                                  assigned_users_list_for_select(current_user, current_user),
-                                  @chosen_user_id
-                                ),
-                                { include_blank: false },
-                                class: "tw-border-blue-500 rounded"
-                %>
-                <%= form.submit "Switch client", class: "tw-bg-blue-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
-              <% end %>
-            </div>
-          <% end %>
-        </li>
-      </ul>
+<nav class="bg-gray-100 px-4 py-3">
+  <div class="container mx-auto flex items-center justify-between">
+    <div class="flex items-center space-x-4">
+      <a href="/" class="w-10 h-10">
+        <%= image_tag("logo.png", alt: "Logo") %>
+      </a>
+
+      <% def nav_bar_classes(page_path)
+           "no-underline text-gray-700 hover:text-black #{current_page?(page_path) ? 'font-bold text-black' : ''}"
+         end
+      %>
+      <%= link_to "Health records", health_records_path, class: "#{nav_bar_classes(health_records_path)}" %>
+      <%= link_to "Lab tests", lab_tests_path, class: "#{nav_bar_classes(lab_tests_path)}" %>
+      <%= link_to "Measurements", measurements_path, class: "#{nav_bar_classes(measurements_path)}" %>
+      <%= link_to "Biomarkers", biomarkers_path, class: "#{nav_bar_classes(biomarkers_path)}" %>
+      <% if current_user&.admin? %>
+        <%= link_to "Users", admin_users_path, class: "#{nav_bar_classes(admin_users_path)}" %>
+      <% end %>
+      <% if assigned_users? %>
+        <%= form_with url: switch_user_admin_user_path(current_user), method: :post do |form| %>
+          <%= form.select :user_id,
+                          options_for_select(
+                            assigned_users_list_for_select(current_user, current_user),
+                            @chosen_user_id
+                          ),
+                          { include_blank: false },
+                          class: "border-blue-500 rounded"
+          %>
+          <%= form.submit "Switch client", class: "primary-button" %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="flex items-center space-x-4">
       <% if user_signed_in? %>
-        <span> Welcome <%= current_user.full_name %> </span>
-        <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "btn btn-outline-primary", form_class: "sign-out-button" %>
+        <span class="no-underline text-gray-700">Welcome <%= current_user.full_name %></span>
+        <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "outline-primary-button", form_class: "sign-out-button" %>
       <% else %>
-        <%= button_to "Sign in", new_user_session_path, class: "btn btn-success" %>
-        <%= link_to "Sign up", new_user_registration_path, class: "btn btn-outline-success" %>
+        <%= button_to "Sign in", new_user_session_path, class: "create-button" %>
+        <%= link_to "Sign up", new_user_registration_path, class: "outline-primary-button" %>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,9 @@
 </head>
 
 <body>
-<div class="container">
+<%= render "layouts/navbar" %>
 
-  <%= render "layouts/navbar" %>
+<div class="container mx-auto">
 
   <%= render "layouts/flash" %>
 

--- a/app/views/measurements/_detail_view_measurement.html.erb
+++ b/app/views/measurements/_detail_view_measurement.html.erb
@@ -1,43 +1,43 @@
-<div id="<%= dom_id measurement %>" class="tw-border-double tw-shadow-lg tw-ring-4 tw-rounded-lg">
-  <div class="tw-m-8">
+<div id="<%= dom_id measurement %>" class="border-double shadow-lg ring-4 rounded-lg">
+  <div class="m-8">
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>User:</strong>
         <%= measurement.user.full_name %>
       </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>Type:</strong>
         <%= measurement.measurement_type %>
       </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>Value:</strong>
         <%= "#{measurement.value} #{measurement.unit}" %>
       </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>source:</strong>
         <%= measurement.source %>
       </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>Notes:</strong>
         <%= measurement.notes %>
       </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>Created at:</strong>
         <%= format_date_with_time measurement.created_at %>
       </p>
 
-    <p class="tw-pt-2 tw-pr-6">
+    <p class="pt-2 pr-6">
         <strong>Updated at:</strong>
         <%= format_date_with_time measurement.updated_at %>
       </p>
 
       <% if policy(measurement).destroy? %>
-        <%= button_to "Remove this Measurement", measurement, method: :delete, class: "tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+        <%= button_to "Remove this Measurement", measurement, method: :delete, class: "mb-6 delete-button font-bold py-2 px-4 rounded" %>
       <% end %>
 
   </div>

--- a/app/views/measurements/_form.html.erb
+++ b/app/views/measurements/_form.html.erb
@@ -1,14 +1,9 @@
 <%= form_with(model: measurement) do |form| %>
   <% if measurement.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(measurement.errors.count, "error") %> prohibited this measurement from being saved:</h2>
-
-      <ul>
-        <% measurement.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render "layouts/error_flash",
+               header: "#{pluralize(measurement.errors.count, "error")} prohibited this measurement from being saved:",
+               errors: measurement.errors.full_messages
+    %>
   <% end %>
 
   <div>
@@ -47,6 +42,6 @@
   </div>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit class: "my-4 edit-button" %>
   </div>
 <% end %>

--- a/app/views/measurements/_measurement.html.erb
+++ b/app/views/measurements/_measurement.html.erb
@@ -1,23 +1,23 @@
-<tr id="<%= dom_id measurement %>" class="tw-bg-white tw-border-b tw-bg-white tw-border-gray-300 tw-hover:bg-gray-700 tw-text-center">
-  <th scope="row" class="tw-px-6 tw-py-4 tw-font-medium tw-text-gray-900 tw-whitespace-nowrap tw-dark:tw-text-white">
+<tr id="<%= dom_id measurement %>" class="bg-white border-b bg-white border-gray-300 hover:bg-gray-700 hover:text-white text-center">
+  <th scope="row" class="px-6 py-4 font-medium whitespace-nowrap">
     <%= measurement.user.full_name %>
   </th>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= measurement.measurement_type %>
   </td>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= "#{measurement.value} #{measurement.unit}" %>
   </td>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= measurement.source %>
   </td>
-  <td class="tw-px-2 tw-py-2 tw-text-ellipsis tw-overflow-hidden tw-max-w-20 tw-whitespace-nowrap">
+  <td class="px-2 py-2 text-ellipsis overflow-hidden max-w-20 whitespace-nowrap">
     <%= measurement.notes %>
   </td>
-  <td class="tw-px-6 tw-py-4">
+  <td class="px-6 py-4">
     <%= format_date_with_time measurement.created_at %>
   </td>
-  <td class="tw-px-6 tw-py-4 tw-items-center">
-    <%= link_to "Show this measurement", measurement, class: "tw-font-medium tw-text-blue-600 tw-dark:tw-text-blue-500 tw-hover:tw-underline" %>
+  <td class="px-6 py-4 items-center">
+    <%= link_to "Show this measurement", measurement, class: "font-medium text-blue-600 dark:text-blue-500 hover:underline" %>
   </td>
 </tr>

--- a/app/views/measurements/edit.html.erb
+++ b/app/views/measurements/edit.html.erb
@@ -1,8 +1,16 @@
-<h1>Editing measurement</h1>
+<h1 class="text-2xl my-3">Editing measurement</h1>
 
 <%= render "form", measurement: @measurement %>
 
 <div>
-  <%= link_to "Show this measurement", @measurement %> |
-  <%= link_to "Back to measurements", measurements_path %>
+  <%= link_to "Show this measurement",
+              @measurement,
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to measurements",
+              measurements_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -1,36 +1,36 @@
 <section>
-  <header class="tw-my-2 tw-flex tw-flex-center tw-justify-between tw-items-center">
-    <h1 class="tw-text-lg">Measurements</h1>
-    <%= link_to "New measurement", new_measurement_path, class: "btn btn-primary" %>
+  <header class="my-2 flex flex-center justify-between items-center">
+    <h1 class="text-center text-2xl my-3">Measurements</h1>
+    <%= link_to "New measurement", new_measurement_path, class: "create-button" %>
   </header>
 
-  <div id="measurements" class="tw-relative tw-overflow-x-auto tw-shadow-md tw-sm:tw-rounded-lg">
+  <div id="measurements" class="relative overflow-x-auto shadow-md sm:rounded-lg">
 
-    <table class="tw-w-full tw-text-sm tw-text-left tw-text-right tw-rounded-md">
+    <table class="w-full text-sm text-left text-right rounded-md">
 
-      <thead class="tw-text-xs tw-text-gray-700 tw-uppercase tw-bg-gray-400 tw-text-center">
+      <thead class="text-xs text-gray-700 uppercase bg-gray-400 text-center">
 
       <tr>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           User
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Type
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Value
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Source
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Notes
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
+        <th scope="col" class="px-6 py-3">
           Created date
         </th>
-        <th scope="col" class="tw-px-6 tw-py-3">
-          <span class="tw-sr-only">Show</span>
+        <th scope="col" class="px-6 py-3">
+          <span class="sr-only">Show</span>
         </th>
       </tr>
 

--- a/app/views/measurements/new.html.erb
+++ b/app/views/measurements/new.html.erb
@@ -1,6 +1,9 @@
-<h1>New measurement</h1>
-
+<h1 class="text-2xl my-3">New measurement</h1>
 
 <div>
-  <%= link_to "Back to measurements", measurements_path %>
+  <%= link_to "Back to measurements",
+              measurements_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -1,14 +1,22 @@
 <%= render "detail_view_measurement", measurement: @measurement %>
 
 <div>
-  <%= link_to "Edit this measurement", edit_measurement_path(@measurement) %> |
-  <%= link_to "Back to measurements", measurements_path %>
+  <%= link_to "Edit this measurement",
+              edit_measurement_path(@measurement),
+              method: :get,
+              class: "edit-button"
+  %>
+  <%= link_to "Back to measurements",
+              measurements_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 
   <%= button_to(
         "Remove this measurement",
         @measurement,
         method: :delete,
         data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-        class: "tw-mt-6 tw-mr-6 tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+        class: "delete-button"
       ) %>
 </div>

--- a/app/views/reference_ranges/_form.html.erb
+++ b/app/views/reference_ranges/_form.html.erb
@@ -1,14 +1,9 @@
 <%= form_with(model: reference_range, url: biomarker_reference_ranges_path, method: :post ) do |form| %>
   <% if reference_range.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(reference_range.errors.count, "error") %> prohibited this reference_range from being saved:</h2>
-
-      <ul>
-        <% reference_range.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
+    <%= render "layouts/error_flash",
+               header: "#{pluralize(reference_range.errors.count, "error")} prohibited this reference range from being saved:",
+               errors: reference_range.errors.full_messages
+    %>
   <% end %>
 
   <div>
@@ -32,6 +27,6 @@
   </div>
 
   <div>
-    <%= form.submit class: "tw-my-4 tw-bg-blue-500  tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded" %>
+    <%= form.submit class: "my-4 create-button" %>
   </div>
 <% end %>

--- a/app/views/reference_ranges/edit.html.erb
+++ b/app/views/reference_ranges/edit.html.erb
@@ -1,8 +1,16 @@
-<h1>Editing reference range</h1>
+<h1 class="text-2xl my-3">Editing reference range</h1>
 
 <%= render "form", reference_range: @reference_range %>
 
 <div>
-  <%= link_to "Show this reference range", @reference_range %> |
-  <%= link_to "Back to reference ranges", reference_ranges_path(@biomarker) %>
+  <%= link_to "Show this reference range",
+              @reference_range,
+              method: :get,
+              class: "primary-button"
+  %>
+  <%= link_to "Back to reference ranges",
+              reference_ranges_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/reference_ranges/index.html.erb
+++ b/app/views/reference_ranges/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Reference ranges</h1>
+ <h1 class="text-2xl my-3">Reference ranges</h1>
 
 <div id="reference_ranges">
   <% @reference_ranges.each do |reference_range| %>
@@ -9,4 +9,8 @@
   <% end %>
 </div>
 
-<%= link_to "New reference range", new_reference_range_path %>
+<%= link_to "New reference range",
+            new_biomarker_reference_range_path(@biomarker),
+            method: :get,
+            class: "create-button"
+%>

--- a/app/views/reference_ranges/new.html.erb
+++ b/app/views/reference_ranges/new.html.erb
@@ -1,7 +1,11 @@
-<h1>New reference range</h1>
+<h1 class="text-2xl my-3">New reference range</h1>
 
 <%= render "form", reference_range: @reference_range %>
 
 <div>
-  <%= link_to "Back to reference ranges", reference_ranges_path(@biomarker) %>
+  <%= link_to "Back to reference ranges",
+              reference_ranges_path,
+              method: :get,
+              class: "secondary-button"
+  %>
 </div>

--- a/app/views/reference_ranges/show.html.erb
+++ b/app/views/reference_ranges/show.html.erb
@@ -2,9 +2,17 @@
 
 <div>
   <% if policy(@reference_range).edit? %>
-    <%= link_to "Edit this reference range", edit_biomarker_reference_range_path(@reference_range) %> |
+    <%= link_to "Edit this reference range",
+                edit_biomarker_reference_range_path(@reference_range),
+                method: :get,
+                class: "edit-button"
+    %>
   <% end %>
-  <%= link_to "Back to reference ranges", reference_ranges_path(@biomarker) %>
+  <%= link_to "Back to reference ranges",
+              reference_ranges_path(@biomarker),
+              method: :get,
+              class: "secondary-button"
+  %>
 
   <% if policy(@reference_range).destroy? %>
     <%= button_to(
@@ -12,7 +20,7 @@
           @reference_range,
           method: :delete,
           data: { turbo_method: :delete, turbo_confirm: "Are you sure?" },
-          class: "tw-mt-6 tw-mr-6 tw-mb-6 tw-bg-red-500 tw-hover:bg-blue-700 tw-text-white tw-font-bold tw-py-2 tw-px-4 tw-rounded"
+          class: "delete-button"
         ) %>
     <% end %>
 </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,5 +7,3 @@ pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
 pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'
-pin 'popper', to: 'popper.js', preload: true
-pin 'bootstrap', to: 'bootstrap.min.js', preload: true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,4 +12,3 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.scss, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-Rails.application.config.assets.precompile += %w[bootstrap.min.js popper.js]

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -7,7 +7,6 @@ module.exports = {
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}'
   ],
-  prefix: "tw-",
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
- Removed Bootstrap (now only TailwindCSS with all it's features).
- Removed `tw-` prefixes for TailwindCSS.
- Fixed all viewes to work with TailwindCSS only.
- Added several alias for buttons (yeah-yeah, I know that this is not a "TailwindCSS way", but simplifies things a lot).
- Updated Readme.
- Synchronized clients lists on Lab Test page:
![image](https://github.com/user-attachments/assets/ae2c5c4e-eb6d-41f4-a4a6-9e10516694dc)
